### PR TITLE
feat: use query endpoints and update test suite

### DIFF
--- a/bullhorn/__init__.py
+++ b/bullhorn/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 __title__ = "bullhorn"
 __author__ = "lloydtao"
 __license__ = "MIT"

--- a/bullhorn/client.py
+++ b/bullhorn/client.py
@@ -146,15 +146,15 @@ class BullhornClient:
 
     def get_appointments(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[appointment.Appointment]:
         request = self.request(
             Route(
                 "GET",
-                self.rest_url + "search/Appointment?query={query}&fields={fields}",
+                self.rest_url + "query/Appointment?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -163,15 +163,15 @@ class BullhornClient:
 
     def get_business_sectors(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[business_sector.BusinessSector]:
         request = self.request(
             Route(
                 "GET",
-                self.rest_url + "search/BusinessSector?query={query}&fields={fields}",
+                self.rest_url + "query/BusinessSector?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -197,15 +197,15 @@ class BullhornClient:
 
     def get_categories(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[category.Category]:
         request = self.request(
             Route(
                 "GET",
-                self.rest_url + "search/Category?query={query}&fields={fields}",
+                self.rest_url + "query/Category?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -214,15 +214,15 @@ class BullhornClient:
 
     def get_client_contacts(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[client_contact.ClientContact]:
         request = self.request(
             Route(
                 "GET",
-                self.rest_url + "search/ClientContact?query={query}&fields={fields}",
+                self.rest_url + "query/ClientContact?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -231,16 +231,15 @@ class BullhornClient:
 
     def get_client_corporations(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[client_corporation.ClientCorporation]:
         request = self.request(
             Route(
                 "GET",
-                self.rest_url
-                + "search/ClientCorporation?query={query}&fields={fields}",
+                self.rest_url + "query/ClientCorporation?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -249,16 +248,16 @@ class BullhornClient:
 
     def get_client_corporation_appointments(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[client_corporation_appointment.ClientCorporationAppointment]:
         request = self.request(
             Route(
                 "GET",
                 self.rest_url
-                + "search/ClientCorporationAppointment?query={query}&fields={fields}",
+                + "query/ClientCorporationAppointment?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -318,15 +317,15 @@ class BullhornClient:
 
     def get_employee_pays(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[employee_pay.EmployeePay]:
         request = self.request(
             Route(
                 "GET",
-                self.rest_url + "search/EmployeePay?query={query}&fields={fields}",
+                self.rest_url + "query/EmployeePay?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -335,16 +334,16 @@ class BullhornClient:
 
     def get_employer_contributions(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[employer_contribution.EmployerContribution]:
         request = self.request(
             Route(
                 "GET",
                 self.rest_url
-                + "search/EmployerContribution?query={query}&fields={fields}",
+                + "query/EmployerContribution?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -353,15 +352,15 @@ class BullhornClient:
 
     def get_job_orders(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[job_order.JobOrder]:
         request = self.request(
             Route(
                 "GET",
-                self.rest_url + "search/JobOrder?query={query}&fields={fields}",
+                self.rest_url + "query/JobOrder?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -370,15 +369,15 @@ class BullhornClient:
 
     def get_job_submissions(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[job_submission.JobSubmission]:
         request = self.request(
             Route(
                 "GET",
-                self.rest_url + "search/JobSubmission?query={query}&fields={fields}",
+                self.rest_url + "query/JobSubmission?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -387,16 +386,16 @@ class BullhornClient:
 
     def get_job_submission_histories(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[job_submission_history.JobSubmissionHistory]:
         request = self.request(
             Route(
                 "GET",
                 self.rest_url
-                + "search/JobSubmissionHistory?query={query}&fields={fields}",
+                + "query/JobSubmissionHistory?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -405,15 +404,15 @@ class BullhornClient:
 
     def get_leads(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[lead.Lead]:
         request = self.request(
             Route(
                 "GET",
-                self.rest_url + "search/Lead?query={query}&fields={fields}",
+                self.rest_url + "query/Lead?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -422,15 +421,15 @@ class BullhornClient:
 
     def get_lead_histories(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[lead_history.LeadHistory]:
         request = self.request(
             Route(
                 "GET",
-                self.rest_url + "search/LeadHistory?query={query}&fields={fields}",
+                self.rest_url + "query/LeadHistory?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -439,15 +438,15 @@ class BullhornClient:
 
     def get_locations(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[location.Location]:
         request = self.request(
             Route(
                 "GET",
-                self.rest_url + "search/Location?query={query}&fields={fields}",
+                self.rest_url + "query/Location?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -456,15 +455,15 @@ class BullhornClient:
 
     def get_opportunities(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[opportunity.Opportunity]:
         request = self.request(
             Route(
                 "GET",
-                self.rest_url + "search/Opportunity?query={query}&fields={fields}",
+                self.rest_url + "query/Opportunity?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -473,16 +472,16 @@ class BullhornClient:
 
     def get_opportunity_histories(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[opportunity_history.OpportunityHistory]:
         request = self.request(
             Route(
                 "GET",
                 self.rest_url
-                + "search/OpportunityHistory?query={query}&fields={fields}",
+                + "query/OpportunityHistory?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -491,15 +490,15 @@ class BullhornClient:
 
     def get_placements(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[placement.Placement]:
         request = self.request(
             Route(
                 "GET",
-                self.rest_url + "search/Placement?query={query}&fields={fields}",
+                self.rest_url + "query/Placement?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )
@@ -526,15 +525,15 @@ class BullhornClient:
 
     def get_sendouts(
         self,
-        query: str,
+        where: str,
         fields: str,
     ) -> List[sendout.Sendout]:
         request = self.request(
             Route(
                 "GET",
-                self.rest_url + "search/Sendout?query={query}&fields={fields}",
+                self.rest_url + "query/Sendout?where={where}&fields={fields}",
                 path_params={
-                    "query": query,
+                    "where": where,
                     "fields": fields,
                 },
             )

--- a/bullhorn/client.py
+++ b/bullhorn/client.py
@@ -159,7 +159,7 @@ class BullhornClient:
                 },
             )
         )
-        return request
+        return request["data"]
 
     def get_business_sectors(
         self,
@@ -176,7 +176,7 @@ class BullhornClient:
                 },
             )
         )
-        return request
+        return request["data"]
 
     def get_candidates(
         self,
@@ -210,7 +210,7 @@ class BullhornClient:
                 },
             )
         )
-        return request
+        return request["data"]
 
     def get_client_contacts(
         self,

--- a/bullhorn/client.py
+++ b/bullhorn/client.py
@@ -105,8 +105,8 @@ class BullhornClient:
                 if 300 > response.status_code >= 200:
                     logger.debug(f"{method} {url} has received {data}")
                     return data
-                # Server error, so retry request with exponential back-off
-                if response.status_code in {500, 502, 503, 504, 524}:
+                # Server error or too many requests, so retry request with exponential back-off
+                if response.status_code in {429, 500, 502, 503, 504, 524}:
                     time.sleep(1 + tries * 2)
                     continue
                 # Client error, so raise exception

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -60,6 +60,66 @@ def test_client_ping(mocker):
     assert "sessionExpires" in result
 
 
+def test_client_get_appointments(mocker):
+    # Mock response
+    return_value = {
+        "total": 1,
+        "start": 0,
+        "count": 1,
+        "data": [
+            {
+                "id": 1234567891011,
+            },
+        ],
+    }
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
+    # Initialise client
+    bc = BullhornClient(
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
+    )
+    # Get result
+    result = bc.get_appointments(
+        where="id >= 0",
+        fields="id,candidateReference,clientContactReference,communicationMethod,dateAdded,dateBegin,isDeleted,jobOrder,lead,opportunity,owner,placement,type",
+    )
+    assert (len(result) == 0) or ("id" in result[0])
+
+
+def test_client_get_business_sectors(mocker):
+    # Mock response
+    return_value = {
+        "total": 1,
+        "start": 0,
+        "count": 1,
+        "data": [
+            {
+                "id": 1234567891011,
+            },
+        ],
+    }
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
+    # Initialise client
+    bc = BullhornClient(
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
+    )
+    # Get result
+    result = bc.get_business_sectors(
+        where="id >= 0",
+        fields="id,dateAdded,name",
+    )
+    assert (len(result) == 0) or ("id" in result[0])
+
+
 def test_client_get_candidates(mocker):
     # Mock response
     return_value = {
@@ -91,6 +151,36 @@ def test_client_get_candidates(mocker):
         fields="id,businessSectors,candidateSource,category,companyName,dateAdded,email,firstName,interviews,isDeleted,lastName,leads,mobile,name,occupation,owner,payrollStatus,salary,source,status,submissions,userDateAdded",
     )
     assert "firstName" in result[0]
+
+
+def test_client_get_categories(mocker):
+    # Mock response
+    return_value = {
+        "total": 1,
+        "start": 0,
+        "count": 1,
+        "data": [
+            {
+                "id": 1234567891011,
+            },
+        ],
+    }
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
+    # Initialise client
+    bc = BullhornClient(
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
+    )
+    # Get result
+    result = bc.get_categories(
+        where="id >= 0",
+        fields="id,dateAdded,name,occupation,type",
+    )
+    assert (len(result) == 0) or ("id" in result[0])
 
 
 def test_client_get_client_contacts(mocker):
@@ -157,6 +247,36 @@ def test_client_get_client_corporations(mocker):
     assert "name" in result[0]
 
 
+def test_client_get_client_corporation_appointments(mocker):
+    # Mock response
+    return_value = {
+        "total": 1,
+        "start": 0,
+        "count": 1,
+        "data": [
+            {
+                "id": 1234567891011,
+            },
+        ],
+    }
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
+    # Initialise client
+    bc = BullhornClient(
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
+    )
+    # Get result
+    result = bc.get_client_corporation_appointments(
+        where="id >= 0",
+        fields="id,clientCorporation,clientContact,appointment",
+    )
+    assert (len(result) == 0) or ("id" in result[0])
+
+
 def test_client_get_corporate_users(mocker):
     # Mock response
     return_value = {
@@ -189,6 +309,126 @@ def test_client_get_corporate_users(mocker):
         fields="id,email,firstName,isDeleted,lastName,mobile,name,occupation,status,userType,username",
     )
     assert "username" in result[0]
+
+
+def test_client_get_countries(mocker):
+    # Mock response
+    return_value = {
+        "total": 1,
+        "start": 0,
+        "count": 1,
+        "data": [
+            {
+                "id": 1234567891011,
+            },
+        ],
+    }
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
+    # Initialise client
+    bc = BullhornClient(
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
+    )
+    # Get result
+    result = bc.get_countries(
+        where="id >= 0",
+        fields="id,code,name",
+    )
+    assert (len(result) == 0) or ("id" in result[0])
+
+
+def test_client_get_departments(mocker):
+    # Mock response
+    return_value = {
+        "total": 1,
+        "start": 0,
+        "count": 1,
+        "data": [
+            {
+                "id": 1234567891011,
+            },
+        ],
+    }
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
+    # Initialise client
+    bc = BullhornClient(
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
+    )
+    # Get result
+    result = bc.get_departments(
+        where="id >= 0",
+        fields="id,name",
+    )
+    assert (len(result) == 0) or ("id" in result[0])
+
+
+def test_client_get_employee_pays(mocker):
+    # Mock response
+    return_value = {
+        "total": 1,
+        "start": 0,
+        "count": 1,
+        "data": [
+            {
+                "id": 1234567891011,
+            },
+        ],
+    }
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
+    # Initialise client
+    bc = BullhornClient(
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
+    )
+    # Get result
+    result = bc.get_employee_pays(
+        where="id >= 0",
+        fields="id,amount,chargeDate,department,earnCodeName,hoursUnits,hoursWorked,jobCode,location,payCheck,projPhase,projWork,shift,unitRate,workCompID",
+    )
+    assert (len(result) == 0) or ("id" in result[0])
+
+
+def test_client_get_employer_contributions(mocker):
+    # Mock response
+    return_value = {
+        "total": 1,
+        "start": 0,
+        "count": 1,
+        "data": [
+            {
+                "id": 1234567891011,
+            },
+        ],
+    }
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
+    # Initialise client
+    bc = BullhornClient(
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
+    )
+    # Get result
+    result = bc.get_employer_contributions(
+        where="id >= 0",
+        fields="id,amount,code,description,payCheck",
+    )
+    assert (len(result) == 0) or ("id" in result[0])
 
 
 def test_client_get_job_orders(mocker):
@@ -252,6 +492,186 @@ def test_client_get_job_submissions(mocker):
         fields="id,appointments,billRate,candidate,dateAdded,dateLastModified,endDate,isDeleted,jobOrder,latestAppointment,owners,payRate,salary,sendingUser,source,startDate,status",
     )
     assert "endDate" in result[0]
+
+
+def test_client_get_job_submission_histories(mocker):
+    # Mock response
+    return_value = {
+        "total": 1,
+        "start": 0,
+        "count": 1,
+        "data": [
+            {
+                "id": 1234567891011,
+            },
+        ],
+    }
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
+    # Initialise client
+    bc = BullhornClient(
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
+    )
+    # Get result
+    result = bc.get_job_submission_histories(
+        where="id >= 0",
+        fields="id,dateAdded,jobSubmission,modifyingUser,status",
+    )
+    assert (len(result) == 0) or ("id" in result[0])
+
+
+def test_client_get_leads(mocker):
+    # Mock response
+    return_value = {
+        "total": 1,
+        "start": 0,
+        "count": 1,
+        "data": [
+            {
+                "id": 1234567891011,
+            },
+        ],
+    }
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
+    # Initialise client
+    bc = BullhornClient(
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
+    )
+    # Get result
+    result = bc.get_leads(
+        where="id >= 0",
+        fields="id,assignedTo,businessSectors,campaignSource,candidates,category,clientContacts,clientCorporation,companyName,dateAdded,dateLastModified,email,firstName,isDeleted,lastName,leadSource,name,occupation,owner,role,salary,status,type",
+    )
+    assert (len(result) == 0) or ("id" in result[0])
+
+
+def test_client_get_lead_histories(mocker):
+    # Mock response
+    return_value = {
+        "total": 1,
+        "start": 0,
+        "count": 1,
+        "data": [
+            {
+                "id": 1234567891011,
+            },
+        ],
+    }
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
+    # Initialise client
+    bc = BullhornClient(
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
+    )
+    # Get result
+    result = bc.get_lead_histories(
+        where="id >= 0",
+        fields="id,clientCorporation,dateAdded,lead,modifyingUser,status",
+    )
+    assert (len(result) == 0) or ("id" in result[0])
+
+
+def test_client_get_locations(mocker):
+    # Mock response
+    return_value = {
+        "total": 1,
+        "start": 0,
+        "count": 1,
+        "data": [
+            {
+                "id": 1234567891011,
+            },
+        ],
+    }
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
+    # Initialise client
+    bc = BullhornClient(
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
+    )
+    # Get result
+    result = bc.get_locations(
+        where="id >= 0",
+        fields="dateAdded,dateLastModified,owner,status,title",
+    )
+    assert (len(result) == 0) or ("id" in result[0])
+
+
+def test_client_get_opportunities(mocker):
+    # Mock response
+    return_value = {
+        "total": 1,
+        "start": 0,
+        "count": 1,
+        "data": [
+            {
+                "id": 1234567891011,
+            },
+        ],
+    }
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
+    # Initialise client
+    bc = BullhornClient(
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
+    )
+    # Get result
+    result = bc.get_opportunities(
+        where="id >= 0",
+        fields="id,assignedUsers,category,clientContact,clientCorporation,dateAdded,dateLastModified,dealValue,effectiveDate,estimatedDuration,estimatedEndDate,estimatedHoursPerWeek,estimatedStartDate,expectedCloseDate,expectedFee,expectedPayRate,isDeleted,isOpen,jobOrders,lead,owner,salary,source,title",
+    )
+    assert (len(result) == 0) or ("id" in result[0])
+
+
+def test_client_get_opportunity_histories(mocker):
+    # Mock response
+    return_value = {
+        "total": 1,
+        "start": 0,
+        "count": 1,
+        "data": [
+            {
+                "id": 1234567891011,
+            },
+        ],
+    }
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
+    # Initialise client
+    bc = BullhornClient(
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
+    )
+    # Get result
+    result = bc.get_opportunity_histories(
+        where="id >= 0",
+        fields="id,dateAdded,dealValue,effectiveDate,modifyingUser,opportunity,status",
+    )
+    assert (len(result) == 0) or ("id" in result[0])
 
 
 def test_client_get_placements(mocker):
@@ -321,3 +741,33 @@ def test_client_get_placement_commissions(mocker):
         fields="id,commissionPercentage,dateAdded,dateLastModified,flatPayout,grossMarginPercentage,hourlyPayout,placement,role,status,user",
     )
     assert "commissionPercentage" in result[0]
+
+
+def test_client_get_sendouts(mocker):
+    # Mock response
+    return_value = {
+        "total": 1,
+        "start": 0,
+        "count": 1,
+        "data": [
+            {
+                "id": 1234567891011,
+            },
+        ],
+    }
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
+    # Initialise client
+    bc = BullhornClient(
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
+    )
+    # Get result
+    result = bc.get_sendouts(
+        where="id >= 0",
+        fields="id,candidate,clientContact,clientCorporation,dateAdded,email,isRead,jobOrder,user",
+    )
+    assert (len(result) == 0) or ("id" in result[0])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -87,8 +87,8 @@ def test_client_get_candidates(mocker):
     )
     # Get result
     result = bc.get_candidates(
-        fields="id,firstName,middleName,lastName",
         query="dateLastModified:{1970/01/01 TO *}",
+        fields="id,businessSectors,candidateSource,category,companyName,dateAdded,email,firstName,interviews,isDeleted,lastName,leads,mobile,name,occupation,owner,payrollStatus,salary,source,status,submissions,userDateAdded",
     )
     assert "firstName" in result[0]
 
@@ -121,7 +121,7 @@ def test_client_get_client_contacts(mocker):
     # Get result
     result = bc.get_client_contacts(
         query="dateLastModified:{2023/01/01 TO *}",
-        fields="id,firstName,middleName,lastName",
+        fields="id,businessSectors,category,clientCorporation,dateAdded,dateLastModified,division,email,firstName,isDeleted,lastName,leads,name,occupation,owner,source,status,type",
     )
     assert "lastName" in result[0]
 
@@ -152,7 +152,7 @@ def test_client_get_client_corporations(mocker):
     # Get result
     result = bc.get_client_corporations(
         query="dateLastModified:{2023/01/01 TO *}",
-        fields="id,name",
+        fields="id,businessSectorList,clientContacts,companyURL,dateAdded,dateFounded,dateLastModified,department,exemptionStatus,feeArrangement,industryList,leads,name,owners,revenue,status",
     )
     assert "name" in result[0]
 
@@ -186,7 +186,7 @@ def test_client_get_corporate_users(mocker):
     # Get result
     result = bc.get_corporate_users(
         where="id >= 0",
-        fields="id,firstName,middleName,lastName,username",
+        fields="id,email,firstName,isDeleted,lastName,mobile,name,occupation,status,userType,username",
     )
     assert "username" in result[0]
 
@@ -224,7 +224,7 @@ def test_client_get_job_orders(mocker):
     # Get result
     result = bc.get_job_orders(
         query="dateLastModified:{2023/01/01 TO *}",
-        fields="id,description,owner",
+        fields="id,appointments,approvedPlacements,assignedUsers,billRateCategoryID,billingProfile,bonusPackage,branch,businessSectors,categories,clientBillRate,clientContact,clientCorporation,dateAdded,dateClosed,dateEnd,dateLastModified,description,durationWeeks,employmentType,feeArrangement,interviews,isDeleted,isOpen,isPublic,jobCode,numOpenings,opportunity,owner,payRate,placements,reasonClosed,salary,salaryUnit,source,startDate,status,submissions,title,usersAssigned",
     )
     assert "owner" in result[0]
 
@@ -265,7 +265,7 @@ def test_client_get_job_submissions(mocker):
     # Get result
     result = bc.get_job_submissions(
         query="dateLastModified:{2023/01/01 TO *}",
-        fields="id,endDate,owners,startDate",
+        fields="id,appointments,billRate,candidate,dateAdded,dateLastModified,endDate,isDeleted,jobOrder,latestAppointment,owners,payRate,salary,sendingUser,source,startDate,status",
     )
     assert "owners" in result[0]
 
@@ -296,7 +296,7 @@ def test_client_get_placements(mocker):
     # Get result
     result = bc.get_placements(
         query="dateLastModified:{2023/01/01 TO *}",
-        fields="id,fee",
+        fields="id,appointments,billingFrequency,bonusPackage,candidate,clientBillRate,clientOvertimeRate,commissions,dateAdded,dateBegin,dateClientEffective,dateEffective,dateEnd,dateLastModified,durationWeeks,employeeType,employmentStartDate,employmentType,fee,jobOrder,jobSubmission,location,owner,payRate,salary,salaryUnit,status",
     )
     assert "fee" in result[0]
 
@@ -334,6 +334,6 @@ def test_client_get_placement_commissions(mocker):
     # Get result
     result = bc.get_placement_commissions(
         where="id >= 0",
-        fields="id,user,commissionPercentage",
+        fields="id,commissionPercentage,dateAdded,dateLastModified,flatPayout,grossMarginPercentage,hourlyPayout,placement,role,status,user",
     )
     assert "commissionPercentage" in result[0]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -87,8 +87,8 @@ def test_client_get_candidates(mocker):
     )
     # Get result
     result = bc.get_candidates(
-        query="dateLastModified:{2023/01/01 TO *}",
         fields="id,firstName,middleName,lastName",
+        query="dateLastModified:{1970/01/01 TO *}",
     )
     assert "firstName" in result[0]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -120,7 +120,7 @@ def test_client_get_client_contacts(mocker):
     )
     # Get result
     result = bc.get_client_contacts(
-        query="dateLastModified:{2023/01/01 TO *}",
+        where="id >= 0",
         fields="id,businessSectors,category,clientCorporation,dateAdded,dateLastModified,division,email,firstName,isDeleted,lastName,leads,name,occupation,owner,source,status,type",
     )
     assert "lastName" in result[0]
@@ -151,7 +151,7 @@ def test_client_get_client_corporations(mocker):
     )
     # Get result
     result = bc.get_client_corporations(
-        query="dateLastModified:{2023/01/01 TO *}",
+        where="id >= 0",
         fields="id,businessSectorList,clientContacts,companyURL,dateAdded,dateFounded,dateLastModified,department,exemptionStatus,feeArrangement,industryList,leads,name,owners,revenue,status",
     )
     assert "name" in result[0]
@@ -223,7 +223,7 @@ def test_client_get_job_orders(mocker):
     )
     # Get result
     result = bc.get_job_orders(
-        query="dateLastModified:{2023/01/01 TO *}",
+        where="id >= 0",
         fields="id,appointments,approvedPlacements,assignedUsers,billRateCategoryID,billingProfile,bonusPackage,branch,businessSectors,categories,clientBillRate,clientContact,clientCorporation,dateAdded,dateClosed,dateEnd,dateLastModified,description,durationWeeks,employmentType,feeArrangement,interviews,isDeleted,isOpen,isPublic,jobCode,numOpenings,opportunity,owner,payRate,placements,reasonClosed,salary,salaryUnit,source,startDate,status,submissions,title,usersAssigned",
     )
     assert "owner" in result[0]
@@ -264,7 +264,7 @@ def test_client_get_job_submissions(mocker):
     )
     # Get result
     result = bc.get_job_submissions(
-        query="dateLastModified:{2023/01/01 TO *}",
+        where="id >= 0",
         fields="id,appointments,billRate,candidate,dateAdded,dateLastModified,endDate,isDeleted,jobOrder,latestAppointment,owners,payRate,salary,sendingUser,source,startDate,status",
     )
     assert "owners" in result[0]
@@ -295,7 +295,7 @@ def test_client_get_placements(mocker):
     )
     # Get result
     result = bc.get_placements(
-        query="dateLastModified:{2023/01/01 TO *}",
+        where="id >= 0",
         fields="id,appointments,billingFrequency,bonusPackage,candidate,clientBillRate,clientOvertimeRate,commissions,dateAdded,dateBegin,dateClientEffective,dateEffective,dateEnd,dateLastModified,durationWeeks,employeeType,employmentStartDate,employmentType,fee,jobOrder,jobSubmission,location,owner,payRate,salary,salaryUnit,status",
     )
     assert "fee" in result[0]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,5 @@
+import os
+
 from typing import List
 
 from bullhorn import __version__
@@ -14,12 +16,26 @@ from bullhorn.types import (
     placement_commission,
 )
 
+# Set test suite defaults
+TEST_SESSION_TOKEN = os.environ.get(
+    "TEST_SESSION_TOKEN",
+    "https://rest123.bullhornstaffing.com/rest-services/1234/",
+)
+TEST_REST_URL = os.environ.get(
+    "TEST_REST_URL",
+    "12345_1234567_a12345bc-123a-45bc-67de-12345678910a",
+)
+TEST_USE_ENV_CREDENTIALS = os.environ.get(
+    "TEST_USE_ENV_CREDENTIALS",
+    False,
+)
+
 
 def test_client_user_agent():
     # Initialise client
     bc = BullhornClient(
-        token="12345_1234567_a12345bc-123a-45bc-67de-12345678910a",
-        rest_url="https://rest123.bullhornstaffing.com/rest-services/1234/",
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
     )
     # Get user agent
     user_agent = bc.user_agent
@@ -29,14 +45,15 @@ def test_client_user_agent():
 def test_client_ping(mocker):
     # Mock response
     return_value: ping.Ping = {"sessionExpires": 1234567891011}
-    mocker.patch(
-        "bullhorn.client.BullhornClient.request",
-        return_value=return_value,
-    )
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
     # Initialise client
     bc = BullhornClient(
-        token="12345_1234567_a12345bc-123a-45bc-67de-12345678910a",
-        rest_url="https://rest123.bullhornstaffing.com/rest-services/1234/",
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
     )
     # Get result
     result = bc.ping()
@@ -58,14 +75,15 @@ def test_client_get_candidates(mocker):
             },
         ],
     }
-    mocker.patch(
-        "bullhorn.client.BullhornClient.request",
-        return_value=return_value,
-    )
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
     # Initialise client
     bc = BullhornClient(
-        token="12345_1234567_a12345bc-123a-45bc-67de-12345678910a",
-        rest_url="https://rest123.bullhornstaffing.com/rest-services/1234/",
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
     )
     # Get result
     result = bc.get_candidates(
@@ -90,14 +108,15 @@ def test_client_get_client_contacts(mocker):
             },
         ],
     }
-    mocker.patch(
-        "bullhorn.client.BullhornClient.request",
-        return_value=return_value,
-    )
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
     # Initialise client
     bc = BullhornClient(
-        token="12345_1234567_a12345bc-123a-45bc-67de-12345678910a",
-        rest_url="https://rest123.bullhornstaffing.com/rest-services/1234/",
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
     )
     # Get result
     result = bc.get_client_contacts(
@@ -120,14 +139,15 @@ def test_client_get_client_corporations(mocker):
             },
         ],
     }
-    mocker.patch(
-        "bullhorn.client.BullhornClient.request",
-        return_value=return_value,
-    )
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
     # Initialise client
     bc = BullhornClient(
-        token="12345_1234567_a12345bc-123a-45bc-67de-12345678910a",
-        rest_url="https://rest123.bullhornstaffing.com/rest-services/1234/",
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
     )
     # Get result
     result = bc.get_client_corporations(
@@ -153,14 +173,15 @@ def test_client_get_corporate_users(mocker):
             },
         ],
     }
-    mocker.patch(
-        "bullhorn.client.BullhornClient.request",
-        return_value=return_value,
-    )
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
     # Initialise client
     bc = BullhornClient(
-        token="12345_1234567_a12345bc-123a-45bc-67de-12345678910a",
-        rest_url="https://rest123.bullhornstaffing.com/rest-services/1234/",
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
     )
     # Get result
     result = bc.get_corporate_users(
@@ -190,14 +211,15 @@ def test_client_get_job_orders(mocker):
             },
         ],
     }
-    mocker.patch(
-        "bullhorn.client.BullhornClient.request",
-        return_value=return_value,
-    )
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
     # Initialise client
     bc = BullhornClient(
-        token="12345_1234567_a12345bc-123a-45bc-67de-12345678910a",
-        rest_url="https://rest123.bullhornstaffing.com/rest-services/1234/",
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
     )
     # Get result
     result = bc.get_job_orders(
@@ -230,14 +252,15 @@ def test_client_get_job_submissions(mocker):
             },
         ],
     }
-    mocker.patch(
-        "bullhorn.client.BullhornClient.request",
-        return_value=return_value,
-    )
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
     # Initialise client
     bc = BullhornClient(
-        token="12345_1234567_a12345bc-123a-45bc-67de-12345678910a",
-        rest_url="https://rest123.bullhornstaffing.com/rest-services/1234/",
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
     )
     # Get result
     result = bc.get_job_submissions(
@@ -260,14 +283,15 @@ def test_client_get_placements(mocker):
             },
         ],
     }
-    mocker.patch(
-        "bullhorn.client.BullhornClient.request",
-        return_value=return_value,
-    )
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
     # Initialise client
     bc = BullhornClient(
-        token="12345_1234567_a12345bc-123a-45bc-67de-12345678910a",
-        rest_url="https://rest123.bullhornstaffing.com/rest-services/1234/",
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
     )
     # Get result
     result = bc.get_placements(
@@ -297,14 +321,15 @@ def test_client_get_placement_commissions(mocker):
             },
         ],
     }
-    mocker.patch(
-        "bullhorn.client.BullhornClient.request",
-        return_value=return_value,
-    )
+    if not TEST_USE_ENV_CREDENTIALS:
+        mocker.patch(
+            "bullhorn.client.BullhornClient.request",
+            return_value=return_value,
+        )
     # Initialise client
     bc = BullhornClient(
-        token="12345_1234567_a12345bc-123a-45bc-67de-12345678910a",
-        rest_url="https://rest123.bullhornstaffing.com/rest-services/1234/",
+        token=TEST_SESSION_TOKEN,
+        rest_url=TEST_REST_URL,
     )
     # Get result
     result = bc.get_placement_commissions(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -201,13 +201,6 @@ def test_client_get_job_orders(mocker):
             {
                 "id": 1234567891011,
                 "description": "An example open job to be filled.",
-                "owner": {
-                    "id": 1234567891011,
-                    "firstName": "Example",
-                    "middleName": "C.",
-                    "lastName": "Name",
-                    "username": "ExampleCName",
-                },
             },
         ],
     }
@@ -226,7 +219,7 @@ def test_client_get_job_orders(mocker):
         where="id >= 0",
         fields="id,appointments,approvedPlacements,assignedUsers,billRateCategoryID,billingProfile,bonusPackage,branch,businessSectors,categories,clientBillRate,clientContact,clientCorporation,dateAdded,dateClosed,dateEnd,dateLastModified,description,durationWeeks,employmentType,feeArrangement,interviews,isDeleted,isOpen,isPublic,jobCode,numOpenings,opportunity,owner,payRate,placements,reasonClosed,salary,salaryUnit,source,startDate,status,submissions,title,usersAssigned",
     )
-    assert "owner" in result[0]
+    assert "description" in result[0]
 
 
 def test_client_get_job_submissions(mocker):
@@ -239,15 +232,6 @@ def test_client_get_job_submissions(mocker):
             {
                 "id": 1234567891011,
                 "endDate": 1234567891011,
-                "owners": [
-                    {
-                        "id": 1234567891011,
-                        "firstName": "Example",
-                        "middleName": "C.",
-                        "lastName": "Name",
-                        "username": "ExampleCName",
-                    },
-                ],
                 "startDate": 1234567891012,
             },
         ],
@@ -267,7 +251,7 @@ def test_client_get_job_submissions(mocker):
         where="id >= 0",
         fields="id,appointments,billRate,candidate,dateAdded,dateLastModified,endDate,isDeleted,jobOrder,latestAppointment,owners,payRate,salary,sendingUser,source,startDate,status",
     )
-    assert "owners" in result[0]
+    assert "endDate" in result[0]
 
 
 def test_client_get_placements(mocker):


### PR DESCRIPTION
This pull request adds:
- Search endpoints:
  - Swap search endpoint calls for query endpoints
  - Use correct parameter for search endpoint in test suite
- Test suite:
  - Allow test suite to take credentials from env
  - Tweak mocked returns and assertions in test suite
  - Add unit tests for new data models
- Bug fixes:
  - Fix nested data return in requests
- Improvements:
  - Update range of candidates test query
  - Update fields pulled across test suite
