### PR TITLE
fix: remove pagination from candidates

### DIFF
--- a/bullhorn/__init__.py
+++ b/bullhorn/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.9"
+__version__ = "0.0.10"
 __title__ = "bullhorn"
 __author__ = "lloydtao"
 __license__ = "MIT"

--- a/bullhorn/__init__.py
+++ b/bullhorn/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.10"
+__version__ = "0.0.11"
 __title__ = "bullhorn"
 __author__ = "lloydtao"
 __license__ = "MIT"

--- a/bullhorn/client.py
+++ b/bullhorn/client.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 import time
 from typing import Any, Dict, List, Optional, Union
@@ -34,8 +33,6 @@ from bullhorn.types import (
     placement_commission,
     sendout,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class BullhornClient:

--- a/bullhorn/client.py
+++ b/bullhorn/client.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 import time
 from typing import Any, Dict, List, Optional, Union
@@ -33,6 +34,8 @@ from bullhorn.types import (
     placement_commission,
     sendout,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class BullhornClient:

--- a/bullhorn/client.py
+++ b/bullhorn/client.py
@@ -279,35 +279,21 @@ class BullhornClient:
         Returns:
         - List[Candidate]: A list of candidates matching the query parameters.
         """
-        # Initialise pagination cursor
-        start = 0
-        last = False
-        # Iteratively get data
-        data = []
-        while not last:
-            # Fetch current page
-            request = self.request(
-                Route(
-                    "GET",
-                    self.rest_url
-                    + "search/Candidate?query={query}&fields={fields}&orderBy={order_by}&count={count}&start={start}",
-                    path_params={
-                        "query": query,
-                        "fields": fields,
-                        "order_by": order_by,
-                        "start": start,
-                        "count": count,
-                    },
-                )
+        request = self.request(
+            Route(
+                "GET",
+                self.rest_url
+                + "search/Candidate?query={query}&fields={fields}&orderBy={order_by}&count={count}&start={start}",
+                path_params={
+                    "query": query,
+                    "fields": fields,
+                    "order_by": order_by,
+                    "start": start,
+                    "count": count,
+                },
             )
-            data.extend(request["data"])
-            # Handle end of pagination
-            total = request["total"]
-            if start + count >= total:
-                last = True
-            start += count
-        # Return all data
-        return data
+        )
+        return request["data"]
 
     def get_categories(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -617,7 +617,7 @@ def test_client_get_locations(mocker):
     # Get result
     result = bc.get_locations(
         where="dateLastModified >= 1693522800000",
-        fields="dateAdded,dateLastModified,owner,status,title",
+        fields="id,dateAdded,dateLastModified,owner,status,title",
     )
     assert (len(result) == 0) or ("id" in result[0])
 


### PR DESCRIPTION
This pull request adds:
- Remove internal pagination consumer from `get_candidates` method
  - No other endpoints have pagination built-in; the user of the SDK should implement pagination consumption themselves, or this should be handled in a separate helper method/class
- Remove unused logger
- Add ID to categories unit test 
